### PR TITLE
Correct architectures value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Library for LED
 paragraph= This helping library for beginner to begin to explore arduino easily
 category=Display
 url=https://sites.google.com/view/khalifnovation/home
-architectures=arduino
+architectures=*
 dot_a_linkage=true


### PR DESCRIPTION
The previous `architectures` value caused the Arduino IDE to display a warning when the library is compiled:
```
WARNING: library KT_LED claims to run on (arduino) architecture(s) and may be incompatible with your current board which runs on (avr) architecture(s).
```
The previous architectures value caused the library's examples to be placed under the **File > Examples > INCOMPATIBLE** menu.